### PR TITLE
Add functionality to save segmentation mask during inference for images

### DIFF
--- a/SegGPT/SegGPT_inference/seggpt_engine.py
+++ b/SegGPT/SegGPT_inference/seggpt_engine.py
@@ -52,7 +52,7 @@ def run_one_image(img, tgt, model, device):
 
     output = y[0, y.shape[1]//2:, :, :]
     output = torch.clip((output * imagenet_std + imagenet_mean) * 255, 0, 255)
-    return output, mask
+    return output
 
 
 def inference_image(model, device, img_path, img2_paths, tgt2_paths, output_dir):
@@ -95,13 +95,13 @@ def inference_image(model, device, img_path, img2_paths, tgt2_paths, output_dir)
     """### Run SegGPT on the image"""
     # make random mask reproducible (comment out to make it change)
     torch.manual_seed(2)
-    output, mask = run_one_image(img, tgt, model, device)
-    output = F.interpolate(
-        output[None, ...].permute(0, 3, 1, 2), 
+    mask = run_one_image(img, tgt, model, device)
+    maskmask = F.interpolate(
+        mask[None, ...].permute(0, 3, 1, 2),
         size=[size[1], size[0]], 
         mode='nearest',
     ).permute(0, 2, 3, 1)[0].numpy()
-    output = Image.fromarray((input_image * (0.6 * output / 255 + 0.4)).astype(np.uint8))
+    output = Image.fromarray((input_image * (0.6 * mask / 255 + 0.4)).astype(np.uint8))
 
     img_name = os.path.basename(img_path)
     out_path = os.path.join(output_dir, "output_" + '.'.join(img_name.split('.')[:-1]) + '.png')

--- a/SegGPT/SegGPT_inference/seggpt_engine.py
+++ b/SegGPT/SegGPT_inference/seggpt_engine.py
@@ -96,7 +96,7 @@ def inference_image(model, device, img_path, img2_paths, tgt2_paths, output_dir)
     # make random mask reproducible (comment out to make it change)
     torch.manual_seed(2)
     mask = run_one_image(img, tgt, model, device)
-    maskmask = F.interpolate(
+    mask = F.interpolate(
         mask[None, ...].permute(0, 3, 1, 2),
         size=[size[1], size[0]], 
         mode='nearest',

--- a/SegGPT/SegGPT_inference/seggpt_engine.py
+++ b/SegGPT/SegGPT_inference/seggpt_engine.py
@@ -104,9 +104,12 @@ def inference_image(model, device, img_path, img2_paths, tgt2_paths, output_dir)
     output = Image.fromarray((input_image * (0.6 * mask / 255 + 0.4)).astype(np.uint8))
 
     img_name = os.path.basename(img_path)
+
+    # save segmented output
     out_path = os.path.join(output_dir, "output_" + '.'.join(img_name.split('.')[:-1]) + '.png')
     output.save(out_path)
 
+    # save binary mask
     mask_path = os.path.join(output_dir, "mask_" + '.'.join(img_name.split('.')[:-1]) + '.png')
     mask_image = Image.fromarray(mask.astype(np.uint8))
     mask_image.save(mask_path)

--- a/SegGPT/SegGPT_inference/seggpt_engine.py
+++ b/SegGPT/SegGPT_inference/seggpt_engine.py
@@ -108,7 +108,7 @@ def inference_image(model, device, img_path, img2_paths, tgt2_paths, output_dir)
     output.save(out_path)
 
     mask_path = os.path.join(output_dir, "mask_" + '.'.join(img_name.split('.')[:-1]) + '.png')
-    mask_image = Image.fromarray(mask.detach().cpu().numpy().astype(np.uint8))
+    mask_image = Image.fromarray(mask.astype(np.uint8))
     mask_image.save(mask_path)
 
 

--- a/SegGPT/SegGPT_inference/seggpt_inference.py
+++ b/SegGPT/SegGPT_inference/seggpt_inference.py
@@ -59,10 +59,7 @@ if __name__ == '__main__':
     if args.input_image is not None:
         assert args.prompt_image is not None and args.prompt_target is not None
 
-        img_name = os.path.basename(args.input_image)
-        out_path = os.path.join(args.output_dir, "output_" + '.'.join(img_name.split('.')[:-1]) + '.png')
-
-        inference_image(model, device, args.input_image, args.prompt_image, args.prompt_target, out_path)
+        inference_image(model, device, args.input_image, args.prompt_image, args.prompt_target, args.output_dir)
     
     if args.input_video is not None:
         assert args.prompt_target is not None and len(args.prompt_target) == 1


### PR DESCRIPTION
This pull request introduces a new feature that allows the model to not only generate the segmented images but also save the binary mask produced during the inference process.

Changes made:

- Modified `inference_image` function signature to take the path of the output directory as a parameter rather than the output file path.
- Added code in `inference_image` function to save the binary mask to the specified output directory along with the segmented output image.
- Modified code in `seggpt_inference.py` script to reflect the aforementioned changes

With this change, users can now access the binary masks produced by the model during inference, which can be useful for further analysis or for understanding how the model is segmenting the images.

I have tested these changes with several images and the results were as expected: the model correctly saved both the segmented image and the corresponding mask.

I believe this feature will be a valuable addition to SegGPT, enhancing its capabilities and providing users with more insights into the model's behavior. 

Possible future works include adapting the above functionality to video inference too. Looking forward to your feedback.